### PR TITLE
feat: add strongly typed ChannelMetadata dataclass

### DIFF
--- a/crates/libibt/src/channel.rs
+++ b/crates/libibt/src/channel.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::array::{
@@ -9,10 +10,40 @@ use arrow::datatypes::{DataType, Field, Schema};
 use crate::error::{IbtError, Result};
 use crate::var_header::{VarHeader, VarType};
 
+/// Typed metadata for a single telemetry channel.
+pub struct ChannelMetadata {
+    pub units: String,
+    pub desc: String,
+    pub interpolate: bool,
+}
+
+impl ChannelMetadata {
+    /// Build metadata from a VarHeader.
+    pub fn from_var_header(var: &VarHeader) -> Self {
+        ChannelMetadata {
+            units: var.unit.clone(),
+            desc: var.desc.clone(),
+            interpolate: matches!(var.var_type, VarType::Float | VarType::Double),
+        }
+    }
+
+    /// Convert to a HashMap suitable for Arrow field metadata.
+    pub fn to_hashmap(&self) -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        m.insert("units".to_string(), self.units.clone());
+        m.insert("desc".to_string(), self.desc.clone());
+        m.insert(
+            "interpolate".to_string(),
+            if self.interpolate { "True" } else { "False" }.to_string(),
+        );
+        m
+    }
+}
+
 /// Build an Arrow RecordBatch for a single channel.
 ///
 /// The batch has columns: `timecodes` (Int64 ms) and the channel value column.
-/// Channel metadata (units, desc) is stored in field-level metadata.
+/// Channel metadata (units, desc, interpolate) is stored in field-level metadata.
 pub fn build_channel_batch(
     name: &str,
     timecodes: &Arc<Int64Array>,
@@ -21,14 +52,7 @@ pub fn build_channel_batch(
     buf_len: usize,
     record_count: usize,
 ) -> Result<RecordBatch> {
-    let mut metadata = std::collections::HashMap::new();
-    metadata.insert("units".to_string(), var.unit.clone());
-    metadata.insert("desc".to_string(), var.desc.clone());
-    let interpolate = matches!(var.var_type, VarType::Float | VarType::Double);
-    metadata.insert(
-        "interpolate".to_string(),
-        if interpolate { "True" } else { "False" }.to_string(),
-    );
+    let metadata = ChannelMetadata::from_var_header(var).to_hashmap();
 
     if var.count > 1 {
         return Err(IbtError::OutOfBounds(

--- a/src/libibt/__init__.py
+++ b/src/libibt/__init__.py
@@ -1,4 +1,4 @@
 from libibt._libibt_rs import ibt
-from libibt.base import LogFile
+from libibt.base import ChannelMetadata, LogFile
 
-__all__ = ["ibt", "LogFile"]
+__all__ = ["ibt", "ChannelMetadata", "LogFile"]

--- a/src/libibt/base.py
+++ b/src/libibt/base.py
@@ -10,6 +10,83 @@ if sys.byteorder != "little":
     raise RuntimeError("libibt requires a little-endian platform")
 
 
+@dataclass(frozen=True)
+class ChannelMetadata:
+    """Typed metadata for a telemetry channel.
+
+    Provides typed access to channel metadata stored in PyArrow field metadata.
+    Use ``from_field()`` or ``from_channel_table()`` to extract metadata, and
+    ``to_field_metadata()`` to serialize back to PyArrow format.
+
+    Attributes:
+        units: Unit string (e.g., "m/s", "revs/min").
+        desc: Description of the channel.
+        interpolate: Whether to use linear interpolation when resampling.
+
+    Example:
+        >>> field = log.channels['Speed'].schema.field('Speed')
+        >>> meta = ChannelMetadata.from_field(field)
+        >>> meta.units
+        'm/s'
+        >>> meta.interpolate
+        True
+    """
+
+    units: str = ""
+    desc: str = ""
+    interpolate: bool = False
+
+    @classmethod
+    def from_field(cls, field: pa.Field) -> "ChannelMetadata":
+        """Extract typed metadata from a PyArrow field.
+
+        Args:
+            field: A PyArrow field with metadata dict.
+
+        Returns:
+            ChannelMetadata with decoded and typed values.
+        """
+        m = field.metadata or {}
+        return cls(
+            units=m.get(b"units", b"").decode(),
+            desc=m.get(b"desc", b"").decode(),
+            interpolate=m.get(b"interpolate", b"").decode() == "True",
+        )
+
+    @classmethod
+    def from_channel_table(cls, table: pa.Table) -> "ChannelMetadata":
+        """Extract typed metadata from a channel table.
+
+        Channel tables have exactly two columns: ``timecodes`` and the value
+        column.  This method finds the non-timecodes field and reads its
+        metadata.
+
+        Args:
+            table: A PyArrow table with ``timecodes`` + one value column.
+
+        Returns:
+            ChannelMetadata with decoded and typed values.
+        """
+        for i in range(table.schema.__len__()):
+            field = table.schema.field(i)
+            if field.name != "timecodes":
+                return cls.from_field(field)
+        return cls()
+
+    def to_field_metadata(self) -> dict[bytes, bytes]:
+        """Pack into PyArrow field metadata format.
+
+        Returns:
+            Dict with bytes keys and bytes values suitable for
+            ``pa.Field.with_metadata()``.
+        """
+        return {
+            b"units": self.units.encode(),
+            b"desc": self.desc.encode(),
+            b"interpolate": str(self.interpolate).encode(),
+        }
+
+
 @dataclass(eq=False)
 class LogFile:
     """
@@ -132,11 +209,9 @@ class LogFile:
         channel_names = sorted(resampled.channels.keys())
 
         # Collect metadata for restoration
-        channel_metadata = {}
+        channel_metadata: dict[str, ChannelMetadata] = {}
         for name in channel_names:
-            field = resampled.channels[name].schema.field(name)
-            if field.metadata:
-                channel_metadata[name] = field.metadata
+            channel_metadata[name] = ChannelMetadata.from_channel_table(resampled.channels[name])
 
         # Build the result table
         columns_dict: dict[str, Any] = {"timecodes": union_timecodes}
@@ -146,15 +221,16 @@ class LogFile:
         result = pa.table(columns_dict)
 
         # Restore schema with metadata
-        if channel_metadata:
-            new_fields = []
-            for field in result.schema:
-                if field.name in channel_metadata:
-                    new_fields.append(field.with_metadata(channel_metadata[field.name]))
-                else:
-                    new_fields.append(field)
-            new_schema = pa.schema(new_fields)
-            result = result.cast(new_schema)
+        new_fields = []
+        for field in result.schema:
+            if field.name in channel_metadata:
+                new_fields.append(
+                    field.with_metadata(channel_metadata[field.name].to_field_metadata())
+                )
+            else:
+                new_fields.append(field)
+        new_schema = pa.schema(new_fields)
+        result = result.cast(new_schema)
 
         return result
 
@@ -279,15 +355,11 @@ class LogFile:
 
         for name, channel_table in source.channels.items():
             field = channel_table.schema.field(name)
+            meta = ChannelMetadata.from_field(field)
             channel_timecodes = channel_table.column("timecodes").to_numpy()
             channel_values = channel_table.column(name).to_numpy(zero_copy_only=False)
 
-            should_interpolate = False
-            if field.metadata:
-                interpolate_value = field.metadata.get(b"interpolate", b"").decode("utf-8")
-                should_interpolate = interpolate_value == "True"
-
-            if should_interpolate:
+            if meta.interpolate:
                 resampled_values = np.interp(
                     target_timecodes_np,
                     channel_timecodes,
@@ -303,7 +375,7 @@ class LogFile:
                     resampled_values[leading_mask] = channel_values[0]
 
             output_type = field.type
-            if should_interpolate and pa.types.is_integer(field.type):
+            if meta.interpolate and pa.types.is_integer(field.type):
                 output_type = pa.float64()
 
             new_table = pa.table(
@@ -313,10 +385,9 @@ class LogFile:
                 }
             )
 
-            if field.metadata:
-                new_field = new_table.schema.field(name).with_metadata(field.metadata)
-                new_schema = pa.schema([new_table.schema.field("timecodes"), new_field])
-                new_table = new_table.cast(new_schema)
+            new_field = new_table.schema.field(name).with_metadata(meta.to_field_metadata())
+            new_schema = pa.schema([new_table.schema.field("timecodes"), new_field])
+            new_table = new_table.cast(new_schema)
 
             new_channels[name] = new_table
 

--- a/tests/test_channel_metadata.py
+++ b/tests/test_channel_metadata.py
@@ -1,0 +1,203 @@
+"""Unit tests for ChannelMetadata dataclass."""
+
+import pyarrow as pa
+import pytest
+
+from libibt import ibt, ChannelMetadata
+from libibt.base import LogFile
+
+TEST_FILE = "tests/test_data/test.ibt"
+
+
+# --- Roundtrip tests ---
+
+
+class TestChannelMetadataRoundtrip:
+    def test_roundtrip_all_fields(self):
+        original = ChannelMetadata(units="m/s", desc="Vehicle speed", interpolate=True)
+        field = pa.field("test", pa.float32(), metadata=original.to_field_metadata())
+        restored = ChannelMetadata.from_field(field)
+        assert restored == original
+
+    def test_defaults_roundtrip(self):
+        original = ChannelMetadata()
+        field = pa.field("test", pa.float32(), metadata=original.to_field_metadata())
+        restored = ChannelMetadata.from_field(field)
+        assert restored == original
+
+    def test_interpolate_true_roundtrip(self):
+        meta = ChannelMetadata(interpolate=True)
+        raw = meta.to_field_metadata()
+        assert raw[b"interpolate"] == b"True"
+        field = pa.field("test", pa.float32(), metadata=raw)
+        restored = ChannelMetadata.from_field(field)
+        assert restored.interpolate is True
+
+    def test_interpolate_false_roundtrip(self):
+        meta = ChannelMetadata(interpolate=False)
+        raw = meta.to_field_metadata()
+        assert raw[b"interpolate"] == b"False"
+        field = pa.field("test", pa.float32(), metadata=raw)
+        restored = ChannelMetadata.from_field(field)
+        assert restored.interpolate is False
+
+
+# --- from_field / from_channel_table ---
+
+
+class TestChannelMetadataFromField:
+    def test_from_field_missing_metadata(self):
+        field = pa.field("test", pa.float32())
+        meta = ChannelMetadata.from_field(field)
+        assert meta == ChannelMetadata()
+
+    def test_from_field_partial_metadata(self):
+        field = pa.field("test", pa.float32(), metadata={b"units": b"rpm"})
+        meta = ChannelMetadata.from_field(field)
+        assert meta.units == "rpm"
+        assert meta.desc == ""
+        assert meta.interpolate is False
+
+    def test_from_channel_table(self):
+        meta = ChannelMetadata(units="m/s", desc="speed", interpolate=True)
+        table = pa.table(
+            {
+                "timecodes": pa.array([0, 100], type=pa.int64()),
+                "speed": pa.array([1.0, 2.0], type=pa.float32()),
+            }
+        )
+        field = table.schema.field("speed").with_metadata(meta.to_field_metadata())
+        table = table.cast(pa.schema([table.schema.field("timecodes"), field]))
+
+        restored = ChannelMetadata.from_channel_table(table)
+        assert restored.units == "m/s"
+        assert restored.desc == "speed"
+        assert restored.interpolate is True
+
+
+# --- to_field_metadata ---
+
+
+class TestChannelMetadataToFieldMetadata:
+    def test_all_keys_present(self):
+        meta = ChannelMetadata()
+        raw = meta.to_field_metadata()
+        assert set(raw.keys()) == {b"units", b"desc", b"interpolate"}
+
+    def test_all_values_are_bytes(self):
+        meta = ChannelMetadata(units="rpm", desc="Engine speed", interpolate=True)
+        raw = meta.to_field_metadata()
+        for key, value in raw.items():
+            assert isinstance(key, bytes), f"Key {key!r} is not bytes"
+            assert isinstance(value, bytes), f"Value for {key!r} is not bytes"
+
+
+# --- Dataclass properties ---
+
+
+class TestChannelMetadataProperties:
+    def test_frozen(self):
+        meta = ChannelMetadata(units="rpm")
+        with pytest.raises(AttributeError):
+            meta.units = "m/s"  # type: ignore[misc]
+
+    def test_equality(self):
+        a = ChannelMetadata(units="rpm", desc="test", interpolate=True)
+        b = ChannelMetadata(units="rpm", desc="test", interpolate=True)
+        assert a == b
+
+    def test_inequality(self):
+        a = ChannelMetadata(units="rpm")
+        b = ChannelMetadata(units="m/s")
+        assert a != b
+
+    def test_default_values(self):
+        meta = ChannelMetadata()
+        assert meta.units == ""
+        assert meta.desc == ""
+        assert meta.interpolate is False
+
+
+# --- Real file metadata ---
+
+
+class TestChannelMetadataFromFile:
+    def test_speed_metadata(self):
+        log = ibt(TEST_FILE)
+        meta = ChannelMetadata.from_channel_table(log.channels["Speed"])
+        assert meta.units == "m/s"
+        assert meta.interpolate is True
+        assert meta.desc != ""
+
+    def test_lap_metadata(self):
+        log = ibt(TEST_FILE)
+        meta = ChannelMetadata.from_channel_table(log.channels["Lap"])
+        assert meta.interpolate is False
+
+    def test_rpm_metadata(self):
+        log = ibt(TEST_FILE)
+        meta = ChannelMetadata.from_channel_table(log.channels["RPM"])
+        assert meta.units == "revs/min"
+        assert meta.interpolate is True
+
+
+# --- Preservation through LogFile operations ---
+
+
+class TestChannelMetadataPreservation:
+    @staticmethod
+    def _make_channel(name: str, meta: ChannelMetadata) -> pa.Table:
+        table = pa.table(
+            {
+                "timecodes": pa.array([0, 100, 200], type=pa.int64()),
+                name: pa.array([1.0, 2.0, 3.0], type=pa.float32()),
+            }
+        )
+        field = table.schema.field(name).with_metadata(meta.to_field_metadata())
+        return table.cast(pa.schema([table.schema.field("timecodes"), field]))
+
+    @staticmethod
+    def _make_log(channels: dict[str, pa.Table]) -> LogFile:
+        return LogFile(
+            channels=channels,
+            laps=pa.table(
+                {
+                    "num": pa.array([0], type=pa.int32()),
+                    "start_time": pa.array([0], type=pa.int64()),
+                    "end_time": pa.array([300], type=pa.int64()),
+                }
+            ),
+            metadata={},
+            file_name="test.ibt",
+        )
+
+    def test_preserved_through_select_channels(self):
+        meta = ChannelMetadata(units="rpm", desc="Engine speed", interpolate=True)
+        log = self._make_log({"RPM": self._make_channel("RPM", meta)})
+        result = log.select_channels(["RPM"])
+        assert ChannelMetadata.from_channel_table(result.channels["RPM"]) == meta
+
+    def test_preserved_through_filter_by_time_range(self):
+        meta = ChannelMetadata(units="m/s", desc="speed", interpolate=True)
+        log = self._make_log({"Speed": self._make_channel("Speed", meta)})
+        result = log.filter_by_time_range(0, 150)
+        assert ChannelMetadata.from_channel_table(result.channels["Speed"]) == meta
+
+    def test_preserved_through_filter_by_lap(self):
+        meta = ChannelMetadata(units="deg", desc="steering angle", interpolate=True)
+        log = self._make_log({"Steering": self._make_channel("Steering", meta)})
+        result = log.filter_by_lap(0)
+        assert ChannelMetadata.from_channel_table(result.channels["Steering"]) == meta
+
+    def test_preserved_through_resample_to_timecodes(self):
+        meta = ChannelMetadata(units="rpm", desc="engine", interpolate=True)
+        log = self._make_log({"RPM": self._make_channel("RPM", meta)})
+        target = pa.array([0, 50, 100, 150, 200], type=pa.int64())
+        result = log.resample_to_timecodes(target)
+        assert ChannelMetadata.from_channel_table(result.channels["RPM"]) == meta
+
+    def test_preserved_through_get_channels_as_table(self):
+        meta = ChannelMetadata(units="bar", desc="brake pressure", interpolate=True)
+        log = self._make_log({"BRK": self._make_channel("BRK", meta)})
+        result = log.get_channels_as_table()
+        assert ChannelMetadata.from_field(result.schema.field("BRK")) == meta


### PR DESCRIPTION
## Summary

- Add frozen `ChannelMetadata` dataclass with typed fields (`units: str`, `desc: str`, `interpolate: bool`) replacing raw `dict[bytes, bytes]` metadata access
- Add `from_field()`, `from_channel_table()`, and `to_field_metadata()` helpers for PyArrow interop
- Add Rust `ChannelMetadata` struct with `from_var_header()` and `to_hashmap()` in `channel.rs`
- Refactor all internal metadata handling in `base.py` to use `ChannelMetadata`
- Export `ChannelMetadata` from `libibt.__init__`

## Test plan

- [x] All 56 existing + new tests pass
- [x] Roundtrip tests: construct → serialize → deserialize → equal
- [x] Edge cases: missing metadata, partial metadata
- [x] Preservation through all LogFile operations (select, filter, resample, merge)
- [x] Real file metadata extraction validates against known values

🤖 Generated with [Claude Code](https://claude.com/claude-code)