### PR TITLE
ci: attach Pyodide wheels to GitHub releases

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,3 +47,6 @@ jobs:
 
       - name: Python tests
         run: uv run pytest tests/ -v
+
+  pyodide:
+    uses: ./.github/workflows/pyodide.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -153,6 +153,27 @@ jobs:
     - name: Run tests
       run: uv run --python .venv pytest tests/ -v --tb=short
 
+  pyodide:
+    uses: ./.github/workflows/pyodide.yml
+
+  upload-pyodide:
+    name: Upload Pyodide wheels to GitHub Release
+    runs-on: ubuntu-latest
+    needs: [pyodide]
+    if: github.event_name == 'release'
+    permissions:
+      contents: write
+    steps:
+    - name: Download Pyodide wheels
+      uses: actions/download-artifact@v4
+      with:
+        name: pyodide-wheel
+        path: dist/
+    - name: Upload to GitHub Release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber --repo "${{ github.repository }}"
+
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
@@ -167,11 +188,18 @@ jobs:
       contents: write
 
     steps:
-    - name: Download all artifacts
+    - name: Download CPython wheels
       uses: actions/download-artifact@v4
       with:
+        pattern: wheel-*
         path: dist/
         merge-multiple: true
+
+    - name: Download sdist
+      uses: actions/download-artifact@v4
+      with:
+        name: sdist
+        path: dist/
 
     - name: List artifacts
       run: ls -la dist/

--- a/.github/workflows/pyodide.yml
+++ b/.github/workflows/pyodide.yml
@@ -1,10 +1,7 @@
 name: Pyodide (WebAssembly) Tests
 
 on:
-  push:
-    branches: [ master, main ]
-  pull_request:
-    branches: [ master, main ]
+  workflow_call:
 
 jobs:
   pyodide-build:


### PR DESCRIPTION

Make pyodide.yml a reusable workflow (workflow_call) and invoke it from
both check.yml (PR builds) and publish.yml (release builds). On release
events, a new upload-pyodide job uploads the wasm wheel to the GitHub
Release. The publish job now selectively downloads only CPython wheels
and sdist, keeping the Pyodide wheel out of PyPI.

Closes #11
